### PR TITLE
added new blog post about memory

### DIFF
--- a/_posts/2023/08/2023-08-14-memory.md
+++ b/_posts/2023/08/2023-08-14-memory.md
@@ -1,0 +1,59 @@
+---
+layout: post
+date: 2023-08-04
+title: "The MEMORY Object Update"
+author: graur
+---
+
+In the recently released version [0.31.0](https://github.com/objectionary/eo/releases/tag/0.31.0), we have changed the writing 
+mechanism of the `memory` object. Previously, we could store and write any object to the `memory`. However, with the update, 
+you can no longer write an object with a different type to the `memory`. Only objects of type `int`, `float`, `string`, 
+and `bool` are allowed.
+
+<!--more-->
+
+We believe that using the `memory` object as a storage for any object is incorrect. Therefore, we have modified the logic of 
+how objects are saved in the `memory` object. Let's consider an example before this update:
+
+```
+[] > animal
+  memory 0 > voice
+
+[] > dog
+  animal.voice.write "Woof" > bark  
+```
+
+In this example, we have two objects: `animal` and `dog`. The `animal` object has a `voice` object initialized as `memory` with zero. The `dog` object only has a `bark` object. We then write the string "Woof" to the `voice` object of the animal. It looks strange to write an `int` object first and then try to write a string to it.
+
+You cannot be certain what object is stored in the `memory` at a specific time. This is why we have changed the logic of how objects are saved in the `memory` object.
+
+Now, you can only write objects of similar types. Moreover, only types `int`, `float`, `string`, and `bool` are allowed. The main reason for this change is that we want to store only primitives in the `memory` object. After our update, the code above would look like this:
+
+```
+[] > animal
+  memory "some default voice value" > voice
+
+[] > dog
+  animal.voice.write "Woof" > @ 
+```
+
+This looks more predictable, right? Now we can be certain that the `voice` object is a string. If the `memory` object is initialized with a default value, you can only write objects of the same type, with an equal or lower number of bytes. For example, the following is correct:
+
+```
+[] > right
+  memory 0 > memo
+  memo.write 18591
+```
+
+Here, we initialize an `int` object with 8 bytes, and then we write another `int` object with the same amount of bytes. However, the following is incorrect:
+
+```
+[] > wrong
+  memory 0 > memo
+  memo.write "wrong"
+```
+
+This is incorrect because "0" is of type `int` and "wrong" is of type `string`.
+The examples presented illustrate the difference in behavior before and after the update, highlighting the importance of maintaining a consistent object type within the `memory` object. This ensures that the stored data remains coherent and avoids potential conflicts or misunderstandings.
+
+Overall, the updated logic of the `memory` object enhances the reliability and usability of the system, providing a more intuitive and controlled approach to storing objects.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Updated the logic of the `memory` object to only allow objects of similar types (`int`, `float`, `string`, and `bool`) to be written.
- Added an example to illustrate the difference in behavior before and after the update.
- Enhanced the reliability and usability of the system by providing a more intuitive and controlled approach to storing objects in the `memory` object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->