### PR TITLE
feat(#60): blog post about release `0.36.0`

### DIFF
--- a/_posts/2024/04/2024-04-16-release-0-36-0.md
+++ b/_posts/2024/04/2024-04-16-release-0-36-0.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-date: 2024-04-15
+date: 2024-04-16
 title: "Big changes in 0.36.0"
 author: maxonfjvipon
 ---

--- a/_posts/2024/04/2024-04-16-release-0-36-0.md
+++ b/_posts/2024/04/2024-04-16-release-0-36-0.md
@@ -1,0 +1,139 @@
+---
+layout: post
+date: 2024-04-16
+title: "Big changes in 0.36.0"
+author: maxonfjvipon
+---
+
+It's been a while since our last blog post. All this time we were working hard fixing bugs, 
+creating new objects and improving EO in general. And here it is - release 
+[0.36.0](https://github.com/objectionary/eo/releases/tag/0.36.0) which contains many new features 
+and bug fixes. So this blog post is summary that highlights the most significant changes.
+
+<!--more-->
+### Rho attribute
+The first most significant change is related to special `ρ` (rho) attribute. A few words about it:
+- in general `ρ` attribute refers to the "parent" (or context) of the object. In java, an analog 
+of `ρ` would be `this` keyword
+- every object has `ρ` attribute
+- at the beginning, when object is formed (just created for the fist time), its `ρ` is void 
+(refers to nothing)
+- `ρ` is immutable and may be set only once (the rules of setting will be described in the future 
+blog posts)
+
+### Vertex attribute
+The second significant change is related to `ν` (vertex) attribute. We got rid of it and made our 
+language simpler. 
+
+The purpose of `ν` attribute was uniquely identify object in the universe. Before
+the release [0.36.0](https://github.com/objectionary/eo/releases/tag/0.36.0) every object had such unique
+numeric identifier and EOLANG guarantied that. But we decide that giving such badges to the objects 
+is not really object-oriented. We don't want and don't need to interact with object relying on it 
+has some unique ID. All we want from the object - its behaviour, the functionality it provides. So 
+it just does not matter if object has some identifier or not, the way it behaves with us - that's 
+what really important. 
+
+That's why objects in EOLANG don't have `ν` attribute anymore.
+
+### Caching
+We've changed the logic of object caching in EOLANG. 
+```
+some-object > cached!
+```
+Until now this `!` meant that if we take attributes from the object more that once, they 
+will be calculated only at the first time and cached. Sounds good, but it didn't work as we wanted.
+
+Now `!` means: when cached object is touched for the first time (for example an attribute is taken),
+it's dataized, converted to `bytes` and started behave as the `bytes`. All the next manipulations 
+with the cached object are transferred to the given `bytes`.
+
+### Objects
+We've done a lot of work to removing redundant object, redesigning some old ones and introducing new
+ones.
+
+- object `while` was removed from `bool` and became a
+  [separated](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/while.eo)
+  object written in pure EO. Its logic is still
+  [declarative](https://news.eolang.org/2022-12-22-declarative-while.html) as it was before
+- object `if` also was removed from `bool` and became a
+  [separated](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/if.eo)
+  object
+- object `goto` was
+  [implemented](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/go.eo)
+  in pure EO
+- object `dataized` was 
+  [introduced](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/dataized.eo). 
+  This object dataizes its argument, makes new instance of `bytes` object and behaves as it
+- objects `ram` and `heap` were removed
+- object `malloc` was
+  [introduced](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/malloc.eo). 
+  It's a classic memory management object which can allocate a block in memory, write to it, read 
+  from it and free it.
+- object `memory` was redesigned and
+  [implemented](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/memory.eo)
+  in pure EO. It uses the object `dataized` and `malloc` inside
+
+### Grammar
+We've made EOLANG more strict by making changes in its 
+[grammar rules](https://github.com/objectionary/eo#backus-naur-form):
+- empty lines inside abstract object body are prohibited. Only 1 line in front of abstract object is
+allowed
+
+```
+# Wrong.
+[] > object
+
+  5 > five
+
+  10 > ten
+
+  [] > inner
+
+# Right.
+[] > object
+  5 > five
+  10 > ten
+
+  [] > inner
+```
+- comment in front of named abstract object is mandatory. Comment in front of anonymous (unnamed)
+abstract object is prohibited. Mandatory comment must start with capital letter, end with dot, have
+length >= 64 characters and include only printable characters (`0x20-0x7f`). Comments in front of other 
+top-level objects are optional
+
+```
+# This is a good commentary in front of named abstract object with length >= 64 characters.
+[] > object
+  # This comment is optional but has the same requirements as in front of abstract object.
+  while > @
+    TRUE
+    # This commentary is prohibited and will lead to parsing exception thrown.
+    [i] (i > @)
+```
+
+- `ν` (vertex) attribute is removed from the grammar
+
+```
+# This code won't be parsed.
+TRUE.< > vtx
+```
+
+- explicit object copying is removed. Until now that main purpose of explicit object copying was 
+creating new object with new `ν` (vertex) attribute. But since we got rid of it - there's no more 
+sense to have such operation in EOLANG
+
+```
+# This code won't be parsed.
+TRUE' > copy
+```
+
+- object caching via `!` is no more language feature but just syntax sugar for `dataized` object
+
+```
+some-object > cached!
+# The same as
+(dataized some-object).as-bytes > cached
+```
+
+That's it. This is what we were working on for the last 4 months. We'll try not to make such huge
+breaks between blog posts in the future. So keep following us!

--- a/_posts/2024/04/2024-04-16-release-0-36-0.md
+++ b/_posts/2024/04/2024-04-16-release-0-36-0.md
@@ -1,14 +1,14 @@
 ---
 layout: post
-date: 2024-04-16
+date: 2024-04-15
 title: "Big changes in 0.36.0"
 author: maxonfjvipon
 ---
 
 It's been a while since our last blog post. All this time we were working hard fixing bugs, 
 creating new objects and improving EO in general. And here it is - release 
-[0.36.0](https://github.com/objectionary/eo/releases/tag/0.36.0) which contains many new features 
-and bug fixes. So this blog post is summary that highlights the most significant changes.
+[0.36.0](https://github.com/objectionary/eo/releases/tag/0.36.0) which contains many new features.
+So this blog post is summary that highlights the most significant changes.
 
 <!--more-->
 ### Rho attribute
@@ -19,7 +19,7 @@ of `ρ` would be `this` keyword
 - at the beginning, when object is formed (just created for the fist time), its `ρ` is void 
 (refers to nothing)
 - `ρ` is immutable and may be set only once (the rules of setting will be described in the future 
-blog posts)
+blog post)
 
 ### Vertex attribute
 The second significant change is related to `ν` (vertex) attribute. We got rid of it and made our 
@@ -27,16 +27,16 @@ language simpler.
 
 The purpose of `ν` attribute was uniquely identify object in the universe. Before
 the release [0.36.0](https://github.com/objectionary/eo/releases/tag/0.36.0) every object had such unique
-numeric identifier and EOLANG guarantied that. But we decide that giving such badges to the objects 
+numeric identifier and EO guarantied that. But we decide that giving such badges to the objects 
 is not really object-oriented. We don't want and don't need to interact with object relying on it 
 has some unique ID. All we want from the object - its behaviour, the functionality it provides. So 
 it just does not matter if object has some identifier or not, the way it behaves with us - that's 
 what really important. 
 
-That's why objects in EOLANG don't have `ν` attribute anymore.
+That's why objects in EO don't have `ν` attribute anymore.
 
 ### Caching
-We've changed the logic of object caching in EOLANG. 
+We've changed the logic of object caching in EO. 
 ```
 some-object > cached!
 ```
@@ -48,33 +48,33 @@ it's dataized, converted to `bytes` and started behave as the `bytes`. All the n
 with the cached object are transferred to the given `bytes`.
 
 ### Objects
-We've done a lot of work to removing redundant object, redesigning some old ones and introducing new
+We've done a lot of work to removing redundant objects, redesigning some old ones and introducing new
 ones.
 
 - object `while` was removed from `bool` and became a
-  [separated](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/while.eo)
+  [separated](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/while.eo)
   object written in pure EO. Its logic is still
-  [declarative](https://news.eolang.org/2022-12-22-declarative-while.html) as it was before
+  [declarative](https://news.EO.org/2022-12-22-declarative-while.html) as it was before
 - object `if` also was removed from `bool` and became a
-  [separated](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/if.eo)
+  [separated](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/if.eo)
   object
 - object `goto` was
-  [implemented](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/go.eo)
+  [implemented](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/go.eo)
   in pure EO
 - object `dataized` was 
-  [introduced](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/dataized.eo). 
+  [introduced](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/dataized.eo). 
   This object dataizes its argument, makes new instance of `bytes` object and behaves as it
 - objects `ram` and `heap` were removed
 - object `malloc` was
-  [introduced](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/malloc.eo). 
+  [introduced](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/malloc.eo). 
   It's a classic memory management object which can allocate a block in memory, write to it, read 
   from it and free it.
 - object `memory` was redesigned and
-  [implemented](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/memory.eo)
+  [implemented](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/memory.eo)
   in pure EO. It uses the object `dataized` and `malloc` inside
 
 ### Grammar
-We've made EOLANG more strict by making changes in its 
+We've made EO more strict by making changes in its 
 [grammar rules](https://github.com/objectionary/eo#backus-naur-form):
 - empty lines inside abstract object body are prohibited. Only 1 line in front of abstract object is
 allowed
@@ -118,9 +118,9 @@ top-level objects are optional
 TRUE.< > vtx
 ```
 
-- explicit object copying is removed. Until now that main purpose of explicit object copying was 
+- explicit object copying via `'` is removed. Until now that main purpose of explicit object copying was 
 creating new object with new `ν` (vertex) attribute. But since we got rid of it - there's no more 
-sense to have such operation in EOLANG
+sense to have such operation in EO
 
 ```
 # This code won't be parsed.

--- a/_posts/2024/04/2024-04-16-release-0-36-0.md
+++ b/_posts/2024/04/2024-04-16-release-0-36-0.md
@@ -49,23 +49,26 @@ manipulations with the cached object are transferred to the given `bytes`.
 We've done a lot of work to remove redundant objects, redesign some old ones, and introduce new ones.
 
 - The object `while` was removed from `bool` and became a 
-  [separated](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/while.eo) 
+  [separated](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/while.eo) 
   object written in pure EO. Its logic is still 
   [declarative](https://news.eo.org/2022-12-22-declarative-while.html) as it was before.
 - The object `if` also was removed from `bool` and became a 
-  [separated](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/if.eo) object.
+  [separated](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/if.eo) object.
 - The object `goto` was 
-  [implemented](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/go.eo) in pure EO.
+  [implemented](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/go.eo) in pure EO.
 - The object `dataized` was 
-  [introduced](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/dataized.eo). 
+  [introduced](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/dataized.eo). 
    This object dataizes its argument, makes a new instance of the `bytes` object, and behaves as it.
 - The objects `ram` and `heap` were removed.
 - The object `malloc` was
-  [introduced](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/malloc.eo). 
+  [introduced](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/malloc.eo). 
   It's a classic memory management object that can allocate a block in memory, write to it, read from it, and free it.
 - The object `memory` was redesigned and 
-  [implemented](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/memory.eo) in pure EO. 
+  [implemented](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/memory.eo) in pure EO. 
   It uses the objects `dataized` and `malloc` inside.
+- The object `cage` was 
+  [redesigned](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/eolang/cage.eo).
+  But it's still a "bad" object, which does not belong to EO.
 
 ### Grammar
 We've made EO more strict by making changes in its [grammar rules](https://github.com/objectionary/eo#backus-naur-form):

--- a/_posts/2024/04/2024-04-16-release-0-36-0.md
+++ b/_posts/2024/04/2024-04-16-release-0-36-0.md
@@ -5,79 +5,71 @@ title: "Big changes in 0.36.0"
 author: maxonfjvipon
 ---
 
-It's been a while since our last blog post. All this time we were working hard fixing bugs, 
-creating new objects and improving EO in general. And here it is - release 
-[0.36.0](https://github.com/objectionary/eo/releases/tag/0.36.0) which contains many new features.
-So this blog post is summary that highlights the most significant changes.
+It's been a while since our last blog post. All this time, we were working hard on fixing bugs, 
+creating new objects, and improving EO in general. And here it is - release 
+[0.36.0](https://github.com/objectionary/eo/releases/tag/0.36.0), which contains many new features. 
+So, this blog post is a summary that highlights the most significant changes.
 
 <!--more-->
+
 ### Rho attribute
-The first most significant change is related to special `ρ` (rho) attribute. A few words about it:
-- in general `ρ` attribute refers to the "parent" (or context) of the object. In java, an analog 
-of `ρ` would be `this` keyword
-- every object has `ρ` attribute
-- at the beginning, when object is formed (just created for the fist time), its `ρ` is void 
-(refers to nothing)
-- `ρ` is immutable and may be set only once (the rules of setting will be described in the future 
-blog post)
+The first significant change is related to the special `ρ` (rho) attribute. A few words about it:
+- In general, the `ρ` attribute refers to the "parent" (or context) of the object. In Java, an 
+  analog of `ρ` would be the `this` keyword.
+- Every object has a `ρ` attribute.
+- At the beginning, when an object is formed (just created for the first time), its `ρ` is void (referring to nothing).
+- `ρ` is immutable and may be set only once (the rules of setting will be described in a future blog post).
 
 ### Vertex attribute
-The second significant change is related to `ν` (vertex) attribute. We got rid of it and made our 
-language simpler. 
+The second significant change is related to the `ν` (vertex) attribute. We got rid of it and made our language simpler.
 
-The purpose of `ν` attribute was uniquely identify object in the universe. Before
-the release [0.36.0](https://github.com/objectionary/eo/releases/tag/0.36.0) every object had such unique
-numeric identifier and EO guarantied that. But we decide that giving such badges to the objects 
-is not really object-oriented. We don't want and don't need to interact with object relying on it 
-has some unique ID. All we want from the object - its behaviour, the functionality it provides. So 
-it just does not matter if object has some identifier or not, the way it behaves with us - that's 
-what really important. 
+The purpose of the `ν` attribute was to uniquely identify an object in the universe. Before the 
+release [0.36.0](https://github.com/objectionary/eo/releases/tag/0.36.0), every object had such a 
+unique numeric identifier, and EO guaranteed that. However, we decided that giving such badges to 
+objects is not really object-oriented. We don't want and don't need to interact with objects relying 
+on whether they have some unique ID. All we want from the object is its behavior, the functionality 
+it provides. So, it just does not matter if an object has some identifier or not; the way it behaves 
+with us is what really matters.
 
-That's why objects in EO don't have `ν` attribute anymore.
+That's why objects in EO don't have the `ν` attribute anymore.
 
 ### Caching
-We've changed the logic of object caching in EO. 
+We've changed the logic of object caching in EO.
 ```
 some-object > cached!
 ```
-Until now this `!` meant that if we take attributes from the object more that once, they 
-will be calculated only at the first time and cached. Sounds good, but it didn't work as we wanted.
+Until now, this `!` meant that if we take attributes from the object more than once, they will be 
+calculated only the first time and cached. Sounds good, but it didn't work as we wanted.
 
-Now `!` means: when cached object is touched for the first time (for example an attribute is taken),
-it's dataized, converted to `bytes` and started behave as the `bytes`. All the next manipulations 
-with the cached object are transferred to the given `bytes`.
+Now, `!` means that when a cached object is touched for the first time (for example, an attribute 
+is taken), it's dataized, converted to `bytes`, and starts to behave as the `bytes`. All the next 
+manipulations with the cached object are transferred to the given `bytes`.
 
 ### Objects
-We've done a lot of work to removing redundant objects, redesigning some old ones and introducing new
-ones.
+We've done a lot of work to remove redundant objects, redesign some old ones, and introduce new ones.
 
-- object `while` was removed from `bool` and became a
-  [separated](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/while.eo)
-  object written in pure EO. Its logic is still
-  [declarative](https://news.EO.org/2022-12-22-declarative-while.html) as it was before
-- object `if` also was removed from `bool` and became a
-  [separated](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/if.eo)
-  object
-- object `goto` was
-  [implemented](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/go.eo)
-  in pure EO
-- object `dataized` was 
+- The object `while` was removed from `bool` and became a 
+  [separated](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/while.eo) 
+  object written in pure EO. Its logic is still 
+  [declarative](https://news.eo.org/2022-12-22-declarative-while.html) as it was before.
+- The object `if` also was removed from `bool` and became a 
+  [separated](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/if.eo) object.
+- The object `goto` was 
+  [implemented](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/go.eo) in pure EO.
+- The object `dataized` was 
   [introduced](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/dataized.eo). 
-  This object dataizes its argument, makes new instance of `bytes` object and behaves as it
-- objects `ram` and `heap` were removed
-- object `malloc` was
+   This object dataizes its argument, makes a new instance of the `bytes` object, and behaves as it.
+- The objects `ram` and `heap` were removed.
+- The object `malloc` was
   [introduced](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/malloc.eo). 
-  It's a classic memory management object which can allocate a block in memory, write to it, read 
-  from it and free it.
-- object `memory` was redesigned and
-  [implemented](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/memory.eo)
-  in pure EO. It uses the object `dataized` and `malloc` inside
+  It's a classic memory management object that can allocate a block in memory, write to it, read from it, and free it.
+- The object `memory` was redesigned and 
+  [implemented](https://github.com/objectionary/eo/blob/0.36.0/eo-runtime/src/main/eo/org/EO/memory.eo) in pure EO. 
+  It uses the objects `dataized` and `malloc` inside.
 
 ### Grammar
-We've made EO more strict by making changes in its 
-[grammar rules](https://github.com/objectionary/eo#backus-naur-form):
-- empty lines inside abstract object body are prohibited. Only 1 line in front of abstract object is
-allowed
+We've made EO more strict by making changes in its [grammar rules](https://github.com/objectionary/eo#backus-naur-form):
+- Empty lines inside an abstract object body are prohibited. Only one line in front of an abstract object is allowed.
 
 ```
 # Wrong.
@@ -96,44 +88,40 @@ allowed
 
   [] > inner
 ```
-- comment in front of named abstract object is mandatory. Comment in front of anonymous (unnamed)
-abstract object is prohibited. Mandatory comment must start with capital letter, end with dot, have
-length >= 64 characters and include only printable characters (`0x20-0x7f`). Comments in front of other 
-top-level objects are optional
+- A comment in front of a named abstract object is mandatory. A comment in front of an anonymous 
+(unnamed) abstract object is prohibited. The mandatory comment must start with a capital letter, 
+end with a dot, have a length >= 64 characters, and include only printable characters (`0x20-0x7f`). 
+Comments in front of other top-level objects are optional.
 
 ```
-# This is a good commentary in front of named abstract object with length >= 64 characters.
+# This is a good commentary in front of a named abstract object with a length >= 64 characters.
 [] > object
-  # This comment is optional but has the same requirements as in front of abstract object.
+  # This comment is optional but has the same requirements as in front of an abstract object.
   while > @
     TRUE
-    # This commentary is prohibited and will lead to parsing exception thrown.
+    # This commentary is prohibited and will lead to a parsing exception being thrown.
     [i] (i > @)
 ```
-
-- `ν` (vertex) attribute is removed from the grammar
+- The `ν` (vertex) attribute is removed from the grammar.
 
 ```
 # This code won't be parsed.
 TRUE.< > vtx
 ```
-
-- explicit object copying via `'` is removed. Until now that main purpose of explicit object copying was 
-creating new object with new `ν` (vertex) attribute. But since we got rid of it - there's no more 
-sense to have such operation in EO
+- Explicit object copying via `'` is removed. Until now, the main purpose of explicit object copying 
+was to create a new object with a new `ν` (vertex) attribute. But since we got rid of it, there's 
+no more sense to have such an operation in EO.
 
 ```
 # This code won't be parsed.
 TRUE' > copy
 ```
-
-- object caching via `!` is no more language feature but just syntax sugar for `dataized` object
+- Object caching via `!` is no longer a language feature but just syntax sugar for the `dataized` object.
 
 ```
 some-object > cached!
 # The same as
 (dataized some-object).as-bytes > cached
 ```
-
-That's it. This is what we were working on for the last 4 months. We'll try not to make such huge
+That's it. This is what we were working on for the last 4 months. We'll try not to make such huge 
 breaks between blog posts in the future. So keep following us!


### PR DESCRIPTION
Closes: #60

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces significant changes in EO language version 0.36.0: removal of the `ν` attribute, revamped object caching, object redesigns, stricter grammar rules, and more.

### Detailed summary
- Introduces `ρ` attribute for object context
- Removes `ν` attribute for object identification
- Changes object caching logic
- Redesigns and introduces new objects
- Enforces stricter grammar rules

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->